### PR TITLE
Fix Sonoma calendar request access

### DIFF
--- a/Beam/Configuration/Info.plist
+++ b/Beam/Configuration/Info.plist
@@ -356,6 +356,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Beam uses your events to help you create meeting notes.</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Beam uses your events to help you create meeting notes.</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
macOS Sonoma requires the usage of the new `eventStore.requestFullAccessToEvents` API, the other one is not working anymore. This API requires also a new key in Info.plist