### PR TITLE
Fix crash when moving nodes to the top

### DIFF
--- a/Beam/Classes/Components/BeamTextEdit/BeamTextEdit+DragAndDrop.swift
+++ b/Beam/Classes/Components/BeamTextEdit/BeamTextEdit+DragAndDrop.swift
@@ -457,10 +457,10 @@ extension BeamTextEdit {
             rootNode.cmdManager.beginGroup(with: "Move Multiple Elements")
             let shouldIncreaseIndex = !isMovedNodeSibbling(selectedNodes.first ?? movedNode, andBefore: dragResult.element) || dragResult.shouldBeChild
             for node in selectedNodes {
-                rootNode.cmdManager.reparentElement(node, to: newParent, atIndex: index + offset)
                 if shouldIncreaseIndex {
                     offset += 1
                 }
+                rootNode.cmdManager.reparentElement(node, to: newParent, atIndex: index + offset)
             }
             rootNode.cmdManager.endGroup()
         } else {

--- a/Beam/Classes/Components/BeamTextEdit/BeamTextEdit+DragAndDrop.swift
+++ b/Beam/Classes/Components/BeamTextEdit/BeamTextEdit+DragAndDrop.swift
@@ -456,11 +456,11 @@ extension BeamTextEdit {
             var offset = 0
             rootNode.cmdManager.beginGroup(with: "Move Multiple Elements")
             let shouldIncreaseIndex = !isMovedNodeSibbling(selectedNodes.first ?? movedNode, andBefore: dragResult.element) || dragResult.shouldBeChild
-            for node in selectedNodes {
+            for node in selectedNodes where index >= 0 {
+                rootNode.cmdManager.reparentElement(node, to: newParent, atIndex: index + offset)
                 if shouldIncreaseIndex {
                     offset += 1
                 }
-                rootNode.cmdManager.reparentElement(node, to: newParent, atIndex: index + offset)
             }
             rootNode.cmdManager.endGroup()
         } else {


### PR DESCRIPTION
_Not 100% sure about this one but the crash happened to me a lot, moving a node to the top lead to a crash because index is negative, just put the condition after the offset correction and seems to resolve the crash issue_

Edit: Finally I have prevented bug with condition around the for to avoid any potential creation of other bugs, need to find later why this index can become negative, crash it not happening anymore