### PR TITLE
Feat: Add shift-cmd-c to Point and Shoot to copy with url

### DIFF
--- a/Beam.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Beam.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -456,8 +456,8 @@
         "repositoryURL": "https://github.com/scinfu/SwiftSoup.git",
         "state": {
           "branch": null,
-          "revision": "0837db354faf9c9deb710dc597046edaadf5360f",
-          "version": "2.7.6"
+          "revision": "6778575285177365cbad3e5b8a72f2a20583cfec",
+          "version": "2.4.3"
         }
       },
       {

--- a/Beam/Classes/Components/PointAndShoot/Native/Views/Components/PointAndShootCardPicker.swift
+++ b/Beam/Classes/Components/PointAndShoot/Native/Views/Components/PointAndShootCardPicker.swift
@@ -101,7 +101,8 @@ struct PointAndShootCardPicker: View {
         } onModifierFlagPressed: { event in
             if shouldShowCopyShareView &&
                 event.modifierFlags.contains(.command) && event.keyCode == KeyCode.c.rawValue {
-                copyShoot()
+                let withURL = event.modifierFlags.contains(.shift)
+                copyShoot(withURL: withURL)
                 return true
             }
             return false
@@ -429,9 +430,9 @@ extension PointAndShootCardPicker {
         }
     }
 
-    private func copyShoot() {
+    private func copyShoot(withURL: Bool) {
         guard !justCopied else { return }
-        onShare?(.copy)
+        onShare?(withURL ? .copyWithURL : .copy)
         SoundEffectPlayer.shared.playSound(.beginRecord)
         justCopied = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
@@ -477,7 +478,7 @@ extension PointAndShootCardPicker {
             HStack {
                 ButtonLabel(justCopied ? loc("Copied") : loc("Copy"),
                             icon: justCopied ? "collect-generic" : "editor-url_copy_16") {
-                    copyShoot()
+                    copyShoot(withURL: false)
                 }
                 Spacer()
                 HStack(spacing: 0) {

--- a/Beam/Classes/Components/Sharing/ShareHelper.swift
+++ b/Beam/Classes/Components/Sharing/ShareHelper.swift
@@ -26,10 +26,12 @@ class ShareHelper {
 
     func shareContent(_ elements: [BeamElement], originURL: URL, service: ShareService) async {
         switch service {
-        case .copy:
+        case .copy, .copyWithURL:
+            let url: URL? = service == .copyWithURL ? originURL : nil
             if elements.isEmpty {
-                await setContentToPasteboard(ReadShareableContent(text: originURL.absoluteString))
-            } else if let shareContent = getShareableContent(from: elements) {
+                await setContentToPasteboard(ReadShareableContent(text: originURL.absoluteString, url: url))
+            } else if var shareContent = getShareableContent(from: elements) {
+                shareContent.url = url
                 await setContentToPasteboard(shareContent)
             } else {
                 Logger.shared.logError("Unable to get any content to share", category: .pointAndShoot)
@@ -86,7 +88,12 @@ class ShareHelper {
 
         if let text = content.text ?? content.url?.absoluteString {
             pasteboard.declareTypes([.string], owner: nil)
-            pasteboard.setString(text, forType: .string)
+            if let url = content.url {
+                let attributedString = NSMutableAttributedString(string: text, attributes: [.link: url])
+                pasteboard.writeObjects([attributedString])
+            } else {
+                pasteboard.setString(text, forType: .string)
+            }
         }
 
         // When we have a single image, let's put the file directly in pasteboard

--- a/Beam/Classes/Components/Sharing/ShareHelper.swift
+++ b/Beam/Classes/Components/Sharing/ShareHelper.swift
@@ -89,7 +89,8 @@ class ShareHelper {
         if let text = content.text ?? content.url?.absoluteString {
             pasteboard.declareTypes([.string], owner: nil)
             if let url = content.url {
-                let attributedString = NSMutableAttributedString(string: text, attributes: [.link: url])
+                let urlWithFragment = PreferencesManager.isLinkTextFragmentEnabled ? url.withTextFragment(text) : url
+                let attributedString = NSMutableAttributedString(string: text, attributes: [.link: urlWithFragment])
                 pasteboard.writeObjects([attributedString])
             } else {
                 pasteboard.setString(text, forType: .string)

--- a/Beam/Classes/Components/Sharing/ShareService.swift
+++ b/Beam/Classes/Components/Sharing/ShareService.swift
@@ -16,6 +16,7 @@ enum ShareService: CaseIterable {
     case reddit
     // os
     case copy
+    case copyWithURL
     case email
     case messages
 
@@ -29,7 +30,7 @@ enum ShareService: CaseIterable {
             return "LinkedIn"
         case .reddit:
             return "Reddit"
-        case .copy:
+        case .copy, .copyWithURL:
             return "Copy"
         case .email:
             return "Email"
@@ -48,7 +49,7 @@ enum ShareService: CaseIterable {
             return "social-linkedin_fill"
         case .reddit:
             return "social-reddit_fill"
-        case .copy:
+        case .copy, .copyWithURL:
             return "editor-url_copy_16"
         case .email:
             return "social-mail_fill"
@@ -68,7 +69,7 @@ enum ShareService: CaseIterable {
         }
         var queryItems: [String: String?] = [:]
         switch self {
-        case .copy:
+        case .copy, .copyWithURL:
             return nil
         case .twitter:
             baseURLString = "https://twitter.com/intent/tweet"

--- a/Beam/Classes/Managers/PreferencesManager+Browser.swift
+++ b/Beam/Classes/Managers/PreferencesManager+Browser.swift
@@ -71,6 +71,7 @@ extension PreferencesManager {
     static let showsStatusBarKey = "showsStatusBar"
     static let collectSoundsKey = "collectSounds"
     static let videoCallsAlwaysInSideWindowKey = "videoCallsAlwaysInSideWindow"
+    static let linkTextFragmentKey = "linkTextFragment"
 }
 
 // MARK: - Default Values
@@ -87,6 +88,7 @@ extension PreferencesManager {
     static let showsStatusBarDefault = false
     static let collectSoundsDefault = true
     static let videoCallsAlwaysInSideWindowDefault = true
+    static let linkTextFragmentDefault = true
 }
 
 extension PreferencesManager {
@@ -125,5 +127,8 @@ extension PreferencesManager {
 
     @UserDefault(key: videoCallsAlwaysInSideWindowKey, defaultValue: videoCallsAlwaysInSideWindowDefault, suiteName: BeamUserDefaults.browserPreferences.suiteName)
     static var videoCallsAlwaysInSideWindow: Bool
+
+    @UserDefault(key: linkTextFragmentKey, defaultValue: linkTextFragmentDefault, suiteName: BeamUserDefaults.browserPreferences.suiteName)
+    static var isLinkTextFragmentEnabled: Bool
 
 }

--- a/Beam/Classes/Views/Preferences/BrowserPreferencesView.swift
+++ b/Beam/Classes/Views/Preferences/BrowserPreferencesView.swift
@@ -30,7 +30,7 @@ struct BrowserPreferencesView: View {
     }
 
     private func getSettingsRows() -> [Settings.Row] {
-        var rows = [searchEngineRow, importBrowserDataRow, historyRow, downloadsRow, tabsRow, soundsRow, videoCallsRow, clearCachesRow]
+        var rows = [searchEngineRow, importBrowserDataRow, historyRow, downloadsRow, tabsRow, soundsRow, videoCallsRow, linksRow, clearCachesRow]
 
         if !BeamData.isDefaultBrowser {
             rows.insert(defaultBrowserRow, at: 0)
@@ -99,6 +99,14 @@ struct BrowserPreferencesView: View {
             Text("Video Calls:")
         } content: {
             VideoCallsSection()
+        }
+    }
+
+    private var linksRow: Settings.Row {
+        Settings.Row(hasDivider: true) {
+            Text("Links:")
+        } content: {
+            CopyLinksSection()
         }
     }
 
@@ -453,3 +461,21 @@ struct VideoCallsSection: View {
         }
     }
 }
+
+private struct CopyLinksSection: View {
+    @State private var isLinkTextFragmentEnabled = PreferencesManager.isLinkTextFragmentEnabled
+
+    var body: some View {
+        Toggle(isOn: $isLinkTextFragmentEnabled) {
+            Text("Enable Link Text Fragment on Copy")
+        }
+        .accessibilityIdentifier("link-fragment-checkbox")
+        .toggleStyle(CheckboxToggleStyle())
+        .font(BeamFont.regular(size: 13).swiftUI)
+        .foregroundColor(BeamColor.Generic.text.swiftUI)
+        .onChange(of: isLinkTextFragmentEnabled) {
+            PreferencesManager.isLinkTextFragmentEnabled = $0
+        }
+    }
+}
+

--- a/BeamCore/Extensions/URL+Beam.swift
+++ b/BeamCore/Extensions/URL+Beam.swift
@@ -169,6 +169,25 @@ public extension URL {
         return components.url
     }
 
+    /// Add `:~:text=` url fragment to url to link directly to a text on a page
+    /// will strip previous link fragments and truncate long text fragments to <starts-with>,<ends-with>
+    func withTextFragment(_ text: String) -> URL {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return self }
+
+        var truncatedText = text
+        let limit = 100
+        if text.count > limit {
+            let leader = ","
+            let words = text.split(separator: " ")
+            let prefix = words.prefix(through: 4).joined(separator: " ")
+            let suffix = words.suffix(4).joined(separator: " ")
+            truncatedText = "\(prefix)\(leader)\(suffix)"
+        }
+        components.fragment = ":~:text=\(truncatedText)"
+        return components.url ?? self
+    }
+
+
     var isSearchEngineResultPage: Bool {
         guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false),
               let host = components.host,


### PR DESCRIPTION
- On a Point and Shoort Card, Press **CMD+SHIFT+C** to copy the content + the url as attributed string

I need that so much in my daily work

### Preview

![ScreenRecording2024-11-28at20 17 50-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/6ad47672-60b7-40f2-bc73-bfdee905bca8)
